### PR TITLE
thumb2c batch: score registered owners inside retained regions (--owner-spans, --sweep)

### DIFF
--- a/tools/thumb2c/src/main.rs
+++ b/tools/thumb2c/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use thumb2c::owners::{self, first_error, score, score_extending, Module};
+use thumb2c::owners::{self, first_error, score, score_extending, Module, RegisteredOwner};
 use thumb2c::{lift_owner, tune};
 
 const USAGE: &str = "usage: lifter <command> [args]\n\
@@ -10,11 +10,22 @@ const USAGE: &str = "usage: lifter <command> [args]\n\
       lift, compile, and compare against the ROM bytes\n\
   tune  <overlay>:<addressHex> [--span BYTES] [--name NAME]\n\
       score, then try call respellings line by line and keep improvements\n\
-  batch [--kind WORD] [--limit N] [--all]\n\
+  batch [--kind WORD] [--limit N] [--all] [--owner-spans] [--sweep]\n\
       score every unregistered retained module (scene and script kinds)\n\
-  list  [--kind WORD] [--all]\n\
+  list  [--kind WORD] [--all] [--owner-spans]\n\
       print the retained modules the batch would visit\n\
-Candidates are written under out/lifter/.";
+Candidates are written under out/lifter/.\n\n\
+  --owner-spans   also score (list: also list) every registered owner\n\
+                  (regions.json manual_regions) whose start lies inside the\n\
+                  region, at that owner's own span, in addition to the\n\
+                  region-extent score. Skips owners already mapped to C.\n\
+                  Default behaviour is unchanged when this is absent. batch\n\
+                  and list only.\n\
+  --sweep         with --owner-spans on batch: also retry each owner-span\n\
+                  score with the span widened to the rest of the region, and\n\
+                  report the better of the two (a short registered span can\n\
+                  cut a function that really runs to the next owner or the\n\
+                  region end).";
 
 struct Options {
     positional: Vec<String>,
@@ -29,6 +40,8 @@ struct Options {
     source: Option<PathBuf>,
     only: Option<PathBuf>,
     jobs: Option<usize>,
+    owner_spans: bool,
+    sweep: bool,
 }
 
 fn parse(arguments: &[String]) -> Result<Options, String> {
@@ -45,6 +58,8 @@ fn parse(arguments: &[String]) -> Result<Options, String> {
         source: None,
         only: None,
         jobs: None,
+        owner_spans: false,
+        sweep: false,
     };
     let mut iter = arguments.iter();
     while let Some(argument) = iter.next() {
@@ -77,6 +92,8 @@ fn parse(arguments: &[String]) -> Result<Options, String> {
                 )
             }
             "--all" => options.all = true,
+            "--owner-spans" => options.owner_spans = true,
+            "--sweep" => options.sweep = true,
             "--path" => options.path = Some(value("--path")?),
             "--source" => options.source = Some(PathBuf::from(value("--source")?)),
             "--only" => options.only = Some(PathBuf::from(value("--only")?)),
@@ -359,9 +376,25 @@ fn selected(root: &Path, options: &Options) -> Result<Vec<Module>, String> {
     Ok(modules)
 }
 
+/// The registered owners (from `regions.json`) whose start lies inside `m`.
+fn owners_inside<'a>(m: &Module, registered: &'a [RegisteredOwner]) -> Vec<&'a RegisteredOwner> {
+    registered
+        .iter()
+        .filter(|o| o.overlay == m.overlay && o.entry >= m.entry && o.entry < m.entry + m.span)
+        .collect()
+}
+
 fn list(root: &Path, options: &Options) -> Result<(), String> {
+    let registered = if options.owner_spans {
+        owners::registered_owners(root)?
+    } else {
+        Vec::new()
+    };
     for m in selected(root, options)? {
         println!("{} {} {}", m.key(), m.span, m.kind);
+        for owner in owners_inside(&m, &registered) {
+            println!("  {} span={}", owner.key(), owner.span);
+        }
     }
     Ok(())
 }
@@ -450,6 +483,168 @@ fn batch_one(root: &Path, options: &Options, m: &Module) -> Outcome {
     }
 }
 
+/// True when a single-halfword length mismatch accounts for the entire
+/// difference: the shared prefix matches in full and the only differing
+/// offset is the boundary itself. In this domain that lone halfword is the
+/// trailing 0x0000 pad after `bx` that ELF `.size` counts but a tight
+/// registered span excludes (or the reverse) — not a real mismatch.
+fn trailing_pad(result: &owners::Score) -> bool {
+    result.differing == 1
+        && result.reference == result.candidate + 2
+        && result.report.contains("wrong_instructions=0")
+}
+
+/// One span's score, with the trailing-pad tolerance already applied.
+struct Scored {
+    raw: u32,
+    ranked: u32,
+    pad: bool,
+}
+
+fn describe(result: &owners::Score) -> Scored {
+    let pad = trailing_pad(result);
+    Scored {
+        raw: result.differing,
+        ranked: if pad { 0 } else { result.differing },
+        pad,
+    }
+}
+
+/// Renders one `Scored` as `{prefix}differing_halfwords=N[ {prefix}trailing_pad=1
+/// {prefix}raw_differing_halfwords=N]`, `prefix` distinguishing an owner-span
+/// score from its `--sweep` retry on the same line.
+fn format_scored(prefix: &str, s: &Scored) -> String {
+    let mut out = format!("{prefix}differing_halfwords={}", s.ranked);
+    if s.pad {
+        out.push_str(&format!(
+            " {prefix}trailing_pad=1 {prefix}raw_differing_halfwords={}",
+            s.raw
+        ));
+    }
+    out
+}
+
+/// One registered-owner span's batch result, ranking already applying the
+/// trailing-pad tolerance.
+enum OwnerOutcome {
+    Scored { ranked: u32 },
+    Failed,
+}
+
+/// Scores one registered owner against a region's draft at the owner's own
+/// span (`--owner-spans`), and optionally again at the rest of the region
+/// (`--sweep`) when the owner-span score is not exact — a short registered
+/// span can cut a function that really runs to the next owner or the region
+/// end.
+fn owner_span_one(
+    root: &Path,
+    options: &Options,
+    m: &Module,
+    path: &Path,
+    owner: &RegisteredOwner,
+) -> OwnerOutcome {
+    let owner_key = owner.key();
+    let result = match score(root, path, &owner_key, owner.span) {
+        Ok(result) => result,
+        Err(error) => {
+            let detail = first_error(&error).unwrap_or(error);
+            println!("{owner_key} span={} failed {}", owner.span, detail.trim());
+            return OwnerOutcome::Failed;
+        }
+    };
+    let scored = describe(&result);
+    let region_note = format!("(region {:08x} extent {})", m.entry, m.span);
+    let swept_span = m.entry + m.span - owner.entry;
+    let sweep = options.sweep && scored.ranked > 0 && swept_span != owner.span;
+    if !sweep {
+        println!(
+            "{owner_key} span={} {} {region_note}",
+            owner.span,
+            format_scored("", &scored)
+        );
+        return OwnerOutcome::Scored {
+            ranked: scored.ranked,
+        };
+    }
+    match score(root, path, &owner_key, swept_span) {
+        Ok(swept_result) => {
+            let swept = describe(&swept_result);
+            let best = if swept.ranked < scored.ranked {
+                "sweep"
+            } else {
+                "owner"
+            };
+            println!(
+                "{owner_key} span={} {} {region_note} sweep_span={swept_span} {} best={best}",
+                owner.span,
+                format_scored("", &scored),
+                format_scored("sweep_", &swept)
+            );
+            OwnerOutcome::Scored {
+                ranked: scored.ranked.min(swept.ranked),
+            }
+        }
+        Err(error) => {
+            let detail = first_error(&error).unwrap_or(error);
+            println!(
+                "{owner_key} span={} {} {region_note} sweep_span={swept_span} sweep_failed {}",
+                owner.span,
+                format_scored("", &scored),
+                detail.trim()
+            );
+            OwnerOutcome::Scored {
+                ranked: scored.ranked,
+            }
+        }
+    }
+}
+
+/// Runs the `--owner-spans` pass over every registered owner inside an
+/// already-scored (not failed) region, printing one row per owner and a
+/// summary tally.
+fn owner_spans_pass(root: &Path, options: &Options, modules: &[Module], outcomes: &[Outcome]) {
+    let registered = match owners::registered_owners(root) {
+        Ok(registered) => registered,
+        Err(error) => {
+            println!("owner-spans failed {error}");
+            return;
+        }
+    };
+    let mut jobs_list: Vec<(Module, RegisteredOwner)> = Vec::new();
+    for (m, outcome) in modules.iter().zip(outcomes) {
+        if matches!(outcome, Outcome::Failed) {
+            continue;
+        }
+        for owner in owners_inside(m, &registered) {
+            jobs_list.push((m.clone(), owner.clone()));
+        }
+    }
+    if jobs_list.is_empty() {
+        return;
+    }
+    let results = parallel(&jobs_list, jobs(options), |(m, owner)| {
+        match scratch_path(root, &m.key()) {
+            Ok(path) => owner_span_one(root, options, m, &path, owner),
+            Err(error) => {
+                println!("{} span={} failed {error}", owner.key(), owner.span);
+                OwnerOutcome::Failed
+            }
+        }
+    });
+    let (mut owner_exact, mut owner_differing, mut owner_failed) = (0, 0, 0);
+    for result in &results {
+        match result {
+            OwnerOutcome::Scored { ranked: 0 } => owner_exact += 1,
+            OwnerOutcome::Scored { .. } => owner_differing += 1,
+            OwnerOutcome::Failed => owner_failed += 1,
+        }
+    }
+    println!(
+        "owner_spans={} owner_exact={owner_exact} owner_differing={owner_differing} owner_failed={owner_failed}",
+        jobs_list.len()
+    );
+}
+
 fn batch(root: &Path, options: &Options) -> Result<(), String> {
     let modules = selected(root, options)?;
     let outcomes = parallel(&modules, jobs(options), |m| batch_one(root, options, m));
@@ -480,6 +675,9 @@ fn batch(root: &Path, options: &Options) -> Result<(), String> {
                 .collect::<Vec<_>>()
                 .join(" ")
         );
+    }
+    if options.owner_spans {
+        owner_spans_pass(root, options, &modules, &outcomes);
     }
     Ok(())
 }

--- a/tools/thumb2c/src/owners.rs
+++ b/tools/thumb2c/src/owners.rs
@@ -69,6 +69,60 @@ pub fn modules(root: &Path) -> Result<Vec<Module>, String> {
     Ok(modules)
 }
 
+#[derive(Deserialize)]
+struct Regions {
+    manual_regions: Vec<ManualRegion>,
+}
+
+#[derive(Deserialize)]
+struct ManualRegion {
+    overlay: String,
+    entry: String,
+    span_bytes: u32,
+}
+
+/// One entry from `regions.json`'s `manual_regions`: a function-sized owner
+/// inside (or coinciding with) a retained region, not yet mapped to a C
+/// source file.
+#[derive(Debug, Clone)]
+pub struct RegisteredOwner {
+    pub overlay: String,
+    pub entry: u32,
+    pub span: u32,
+}
+
+impl RegisteredOwner {
+    pub fn key(&self) -> String {
+        format!("{}:{:08x}", self.overlay, self.entry)
+    }
+}
+
+/// Every registered owner in `games/gs1/semantic/regions.json` that has no
+/// mapped C source yet. Unlike `study`/`bench`, which only look at owners
+/// that already have mapped source, this is for finding owners still sitting
+/// inside a retained region's draft.
+pub fn registered_owners(root: &Path) -> Result<Vec<RegisteredOwner>, String> {
+    let path = root.join("games/gs1/semantic/regions.json");
+    let text = std::fs::read(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let regions: Regions =
+        serde_json::from_slice(&text).map_err(|error| format!("{}: {error}", path.display()))?;
+    let sources = SourcePaths::load(root)?;
+    let mut owners = Vec::new();
+    for region in regions.manual_regions {
+        let entry = parse_hex(&region.entry)?;
+        let owner = SourceOwner::parse(&format!("{}:{entry:08x}", region.overlay))?;
+        if sources.mapped_relative_path(owner).is_some() {
+            continue;
+        }
+        owners.push(RegisteredOwner {
+            entry,
+            overlay: region.overlay,
+            span: region.span_bytes,
+        });
+    }
+    Ok(owners)
+}
+
 /// Parses `<overlay>:<hex>` into its parts.
 pub fn parse_owner(owner: &str) -> Result<(String, u32), String> {
     let (overlay, address) = owner


### PR DESCRIPTION
## Summary

`thumb2c batch` scores each retained region at its extent, but many regions hold more than one registered owner (`regions.json` `manual_regions`). Scoring the unchanged draft at the owner's own span instead often links exact already — that observation produced most of the owners in #6, by hand. This makes `thumb2c` do it (supersedes #7, which targeted the removed `lifter`).

- `--owner-spans` (batch, list): after the region pass, score every registered owner whose start lies inside the region at that owner's span; one row per owner (`resource_3a2:02000924 span=412 differing_halfwords=6 (region 02000924 extent 1036)`) and an `owner_spans=… owner_exact=…` summary line.
- `--sweep`: when the owner span is not exact, retry with the span widened to the rest of the region and report both (`sweep_span=… best=owner|sweep`), for owners registered short of the pool island their function really runs to (the `3c5:02001238` / `379:02000074` shape from #6).
- trailing pad: a reference exactly one halfword longer than the candidate with `wrong_instructions=0` is ranked exact and marked `trailing_pad=1` with the raw count kept in the row; `adopt` still decides on the real bytes.

Default output is byte-identical without the flags. No new dependencies; `cargo test` and `cargo fmt --check` clean; `make verify` green.

## On this tree (187bb9749)

`thumb2c batch --all --jobs 8 --owner-spans --sweep`: 184 regions, 270 owner spans, **51 exact from the unchanged draft** (one via the pad rule: `3a6:020011a0`), 12 spans where the widened sweep scores better than the registered span. Of the 386 overlay-assembly regions, 64 nest two or more registered owners; those are the ones the region-extent pass could not see.

## Notes

- Under `--jobs 8` a handful of owner scores come back with `no score line` (23 here); each scores fine when retried alone. That is the existing scorer subprocess path under load, not new code — left as is rather than adding a retry you might prefer to shape.
- The sweep widens to the region end only. Widening to the next registered owner start would be a natural refinement if you want the tool to propose the corrected span for the registry.
