### PR TITLE
shape-search: score an explicit source file through the overlay route (--source/--owner/--span)

### DIFF
--- a/tools/shape-search/src/main.rs
+++ b/tools/shape-search/src/main.rs
@@ -7,6 +7,12 @@
 //! candidate is a legal respelling.
 //!
 //!   shape-search <owner-hex> [rounds]
+//!   shape-search --source FILE --owner <overlay>:<addressHex> --span N [rounds]
+//!
+//! The second form scores FILE directly (edited in place, same as the first
+//! form) via `overlay score FILE --owner <owner> --span N` instead of the
+//! main-image `compiler candidate-show`. Everything past scoring is
+//! identical: same mutation engine, same greedy accept-on-improvement loop.
 
 use regex::Regex;
 use std::collections::BTreeSet;
@@ -29,21 +35,58 @@ fn main() -> ExitCode {
     }
 }
 
+const USAGE: &str = "usage: shape-search <owner-hex> [rounds]\n   or: shape-search --source FILE --owner <overlay>:<addressHex> --span N [rounds]";
+
 fn run() -> Result<(), String> {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let owner = args
-        .first()
-        .cloned()
-        .ok_or("usage: shape-search <owner-hex> [rounds]")?;
-    let rounds: usize = args.get(1).and_then(|r| r.parse().ok()).unwrap_or(4);
     let repo = std::env::current_dir().map_err(|e| e.to_string())?;
-    let relative = format!("games/gs1/recon/en/main/{owner}.c");
-    let file: PathBuf = repo.join(&relative);
-    let scorer = repo.join("out/cargo-target/release/compiler");
+
+    let (owner, file, scorer, scorer_args, rounds): (String, PathBuf, PathBuf, Vec<String>, usize) =
+        if args.first().map(String::as_str) == Some("--source") {
+            let (mut source, mut owner_opt, mut span_opt) = (None, None, None);
+            let mut rest = Vec::new();
+            let mut it = args.iter();
+            while let Some(a) = it.next() {
+                match a.as_str() {
+                    "--source" => source = Some(it.next().ok_or(USAGE)?.clone()),
+                    "--owner" => owner_opt = Some(it.next().ok_or(USAGE)?.clone()),
+                    "--span" => span_opt = Some(it.next().ok_or(USAGE)?.clone()),
+                    other => rest.push(other.to_string()),
+                }
+            }
+            let file = repo.join(source.ok_or(USAGE)?);
+            let owner = owner_opt.ok_or(USAGE)?;
+            let span = span_opt.ok_or(USAGE)?;
+            let rounds = rest.first().and_then(|r| r.parse().ok()).unwrap_or(4);
+            let scorer = repo.join("out/cargo-target/release/overlay");
+            let scorer_args = vec![
+                "score".to_string(),
+                file.to_string_lossy().into_owned(),
+                "--owner".to_string(),
+                owner.clone(),
+                "--span".to_string(),
+                span,
+            ];
+            (owner, file, scorer, scorer_args, rounds)
+        } else {
+            let owner = args.first().cloned().ok_or(USAGE)?;
+            let rounds = args.get(1).and_then(|r| r.parse().ok()).unwrap_or(4);
+            let relative = format!("games/gs1/recon/en/main/{owner}.c");
+            let file = repo.join(&relative);
+            let scorer = repo.join("out/cargo-target/release/compiler");
+            let scorer_args = vec![
+                "candidate-show".to_string(),
+                relative,
+                "--owner".to_string(),
+                owner.clone(),
+            ];
+            (owner, file, scorer, scorer_args, rounds)
+        };
+
     let score = |_: &()| -> u64 {
         let output = Command::new(&scorer)
             .current_dir(&repo)
-            .args(["candidate-show", &relative, "--owner", &owner])
+            .args(&scorer_args)
             .output();
         let Ok(output) = output else { return u64::MAX };
         let text = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

`shape-search <owner-hex>` only reaches main-image owners: it reads `games/gs1/recon/en/main/<owner>.c` and scores through `compiler candidate-show`. The same greedy respelling loop is just as useful on an overlay candidate that a hand pass or `thumb2c tune` left a few halfwords short.

Second form, everything else unchanged:

```
shape-search --source FILE --owner <overlay>:<addressHex> --span N [rounds]
```

scores FILE (edited in place, as the first form does) through `overlay score FILE --owner <owner> --span N`. Mutation engine and accept-on-improvement loop untouched; the first form behaves exactly as before. No new dependencies; `rustfmt --check` clean; `make verify` green.

## Measured

On 33 overlay residuals that hand work had left at `differing_halfwords` 1–40, six rounds each (a few seconds per owner) converted one to exact: `resource_383:02002db4`, 6 → 0, by a single `s32 → s16` retype of a table base local. The other 32 did not move, which matches their scorer class (scheduling and allocation floors that respelling does not reach). Cheap enough to run as a fixed rung before any manual attempt.
