### PR TITLE
Reach overlay owners with the allocator evidence, land main-image owners through adopt, declare scaffolds in place

### DIFF
--- a/tools/alchemy/src/allocator.rs
+++ b/tools/alchemy/src/allocator.rs
@@ -6,7 +6,7 @@ use compiler_core::{
 };
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 const REGS: [&str; 16] = [
@@ -19,7 +19,6 @@ mod tests {
     fn invalid_owners_and_route_overrides_are_rejected_before_compilation() {
         for args in [
             vec!["../../elsewhere"],
-            vec!["resource_3ba:02002910"],
             vec!["080bbb0c", "-fno-cse-follow-jumps"],
             vec!["080bbb0c", "source.c", "extra"],
         ] {
@@ -27,6 +26,84 @@ mod tests {
             assert!(super::run(&args).is_err());
         }
         assert!(super::run(&["--help".into()]).is_ok());
+    }
+
+    /// Compile one owner's draft, then the same text from a path outside the
+    /// draft directory: the report has to be the same, because the compiler
+    /// route and the symbol bindings follow the owner and not the file name.
+    /// Returns the work directory of the first compile with its report.
+    fn dumps_and_report(owner: &str, stem: &str) -> (std::path::PathBuf, String) {
+        let (work, report) = super::inspect(owner, None).unwrap();
+        let dumps = std::fs::read_dir(&work)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        for pass in ["lreg", "greg", "sched2"] {
+            let suffix = format!(".{pass}");
+            assert!(
+                dumps.iter().any(|name| name.ends_with(&suffix)),
+                "no {pass} dump for {owner} among {dumps:?}"
+            );
+        }
+        let elsewhere = tempfile::Builder::new()
+            .suffix(".c")
+            .tempfile()
+            .unwrap()
+            .into_temp_path();
+        let parsed = compiler_core::source_paths::SourceOwner::parse_argument(owner).unwrap();
+        let drafts = if parsed.is_main() { "main" } else { "overlays" };
+        std::fs::copy(
+            compiler_core::routing::root().join(format!("games/gs1/recon/en/{drafts}/{stem}.c")),
+            &elsewhere,
+        )
+        .unwrap();
+        let (_, renamed) = super::inspect(owner, elsewhere.to_str()).unwrap();
+        assert_eq!(renamed, report, "{owner} routed by its candidate's name");
+        (work, report)
+    }
+
+    /// Which image's symbols the compile was bound against. Overlay owners
+    /// live at 0x02......, main-image owners at 0x08......, so the generated
+    /// header says outright which route produced the dumps.
+    fn bound_images(work: &std::path::Path) -> (bool, bool) {
+        let bindings = std::fs::read_to_string(work.join("bindings.h")).unwrap();
+        assert!(!bindings.is_empty(), "no symbol bindings were generated");
+        (bindings.contains("Func_02"), bindings.contains("Func_08"))
+    }
+
+    /// The allocator and scheduling route has to reach overlay owners: their
+    /// drafts are the ones parked on a scheduling residual.
+    #[test]
+    fn an_overlay_owner_dumps_and_reports_its_allocation() {
+        let (work, report) = dumps_and_report("resource_378:0200088c", "resource_378_c_0200088c");
+        // The overlay's own bindings, not the main image's: this is the fix.
+        assert_eq!(bound_images(&work), (true, false));
+        assert!(
+            report.starts_with("resource_378_c_0200088c: 201 pseudos, global order: 222 37 54\n"),
+            "{}",
+            report.lines().next().unwrap_or_default()
+        );
+        assert!(report.contains(
+            "\nspill insns: 96 99 110 113 168 171 465 482 529 546 681 723 778 896 3212 3226 3236\n"
+        ));
+        assert!(report.ends_with("\nreloads: r3 for reload 0; r3 for reload 0; r2 for reload 0; r3 for reload 0; r3 for reload 0; r3 for reload 0; r3 for reload 0"));
+        let rows = report
+            .lines()
+            .filter(|line| line.starts_with(|first: char| first.is_ascii_digit()))
+            .count();
+        assert_eq!(rows, 201);
+        assert!(report.contains("  conflicts: "));
+    }
+
+    /// The main image keeps the report it had, and gains the same
+    /// independence from the candidate's location.
+    #[test]
+    fn a_main_owner_reports_its_allocation_unchanged() {
+        let (work, report) = dumps_and_report("0800300c", "0800300c");
+        assert_eq!(bound_images(&work), (false, true));
+        assert!(report.starts_with("0800300c: 24 pseudos, global order: \n"));
+        assert!(report.ends_with("\nspill insns: 12 18 24 30 36 42 48 54 60 66 72 78"));
     }
 }
 
@@ -41,7 +118,7 @@ pub fn entry(args: &[String]) -> ExitCode {
 }
 
 fn run(args: &[String]) -> Result<(), String> {
-    const USAGE: &str = "usage: alchemy inspect allocator MAIN_OWNER [candidate.c]";
+    const USAGE: &str = "usage: alchemy inspect allocator OWNER [candidate.c]";
     if args == ["--help"] || args == ["-h"] {
         println!("{USAGE}");
         return Ok(());
@@ -49,15 +126,27 @@ fn run(args: &[String]) -> Result<(), String> {
     if args.is_empty() || args.len() > 2 || args.iter().any(|a| a.starts_with('-')) {
         return Err(USAGE.into());
     }
-    let parsed = SourceOwner::parse_argument(&args[0])?;
-    if !parsed.is_main() {
-        return Err("allocator inspection currently requires a main-ROM owner".into());
-    }
-    let owner = format!("{:08x}", parsed.address());
-    let source = args
-        .get(1)
-        .cloned()
-        .unwrap_or_else(|| format!("games/gs1/recon/en/main/{owner}.c"));
+    let (work, report) = inspect(&args[0], args.get(1).map(String::as_str))?;
+    println!("{report}");
+    println!(
+        "dumps kept in {} (cse=03, cse2=09, combine=13, lreg=17, greg=18, sched2=23)",
+        work.display()
+    );
+    Ok(())
+}
+
+/// Compile the owner's candidate with GCC's `-da` dumps and read the
+/// allocation out of them. Compiler route and symbol bindings follow the
+/// owner, so an overlay owner is dumped through the overlay's own route and
+/// its translation unit's bindings; only the draft's directory differs.
+fn inspect(target: &str, candidate: Option<&str>) -> Result<(PathBuf, String), String> {
+    let parsed = SourceOwner::parse_argument(target)?;
+    let owner = parsed.legacy_stem();
+    let source = candidate.map(str::to_string).unwrap_or_else(|| {
+        let drafts = if parsed.is_main() { "main" } else { "overlays" };
+        format!("games/gs1/recon/en/{drafts}/{owner}.c")
+    });
+    let routing = parsed.routing_path().to_string_lossy().into_owned();
     let repo = compiler_core::routing::root();
     let directory = repo.join("out/allocator");
     fs::create_dir_all(&directory).map_err(|e| e.to_string())?;
@@ -76,7 +165,7 @@ fn run(args: &[String]) -> Result<(), String> {
     let bindings = work.join("bindings.h");
     fs::write(
         &bindings,
-        candidate_compiler::verify::source_symbol_bindings(&repo, &source, CompilerTarget::Gs1)?,
+        candidate_compiler::verify::source_symbol_bindings(&repo, &routing, CompilerTarget::Gs1)?,
     )
     .map_err(|e| e.to_string())?;
     cpp.splice(
@@ -84,7 +173,7 @@ fn run(args: &[String]) -> Result<(), String> {
         ["-include".into(), bindings.to_string_lossy().into_owned()],
     );
     checked(Path::new(&cpp[0]), &cpp[1..], &repo)?;
-    let mut cc1 = cflags_for_target_source(CompilerTarget::Gs1, &source);
+    let mut cc1 = cflags_for_target_source(CompilerTarget::Gs1, &routing);
     cc1.retain(|flag| flag != "-nostdinc" && !flag.starts_with("-I"));
     cc1.extend([
         "-quiet".into(),
@@ -231,16 +320,18 @@ fn run(args: &[String]) -> Result<(), String> {
         }
     }
 
-    println!(
-        "{owner}: {} pseudos, global order: {}",
-        creation.len(),
-        order
-            .iter()
-            .map(|n| n.to_string())
-            .collect::<Vec<_>>()
-            .join(" ")
-    );
-    println!("pseudo  hard  var                     pref      order  costs");
+    let mut lines = vec![
+        format!(
+            "{owner}: {} pseudos, global order: {}",
+            creation.len(),
+            order
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        ),
+        "pseudo  hard  var                     pref      order  costs".to_string(),
+    ];
     for p in &creation {
         let hard = assigned
             .get(p)
@@ -255,7 +346,7 @@ fn run(args: &[String]) -> Result<(), String> {
             .position(|o| o == p)
             .map(|i| i.to_string())
             .unwrap_or_else(|| "-".into());
-        println!(
+        lines.push(format!(
             "{:<7} {:<5} {:<23} {:<9} {:<6} {}{}",
             p,
             hard,
@@ -267,19 +358,15 @@ fn run(args: &[String]) -> Result<(), String> {
                 .get(p)
                 .map(|c| format!("  conflicts: {c}"))
                 .unwrap_or_default()
-        );
+        ));
     }
     if !spills.is_empty() {
-        println!("spill insns: {}", spills.join(" "));
+        lines.push(format!("spill insns: {}", spills.join(" ")));
     }
     if !reloads.is_empty() {
-        println!("reloads: {}", reloads.join("; "));
+        lines.push(format!("reloads: {}", reloads.join("; ")));
     }
-    println!(
-        "dumps kept in {} (cse=03, cse2=09, combine=13, lreg=17, greg=18, sched2=23)",
-        work.display()
-    );
-    Ok(())
+    Ok((work, lines.join("\n")))
 }
 
 fn checked(program: &Path, args: &[String], cwd: &Path) -> Result<(), String> {

--- a/tools/alchemy/src/main.rs
+++ b/tools/alchemy/src/main.rs
@@ -165,7 +165,9 @@ fn decompile_command(command: &str, arguments: &[String]) -> ExitCode {
     if arguments == ["--help"] || arguments == ["-h"] {
         let usage = match command {
             "draft" => "decompile OWNER [--span BYTES] [--name NAME] [--out FILE]",
-            "adopt" => "adopt OWNER [--source FILE] [--span BYTES] [--name NAME] [--path PATH]",
+            "adopt" => {
+                "adopt OWNER [--source FILE] [--span BYTES] [--name NAME] [--path PATH] [--apply]"
+            }
             "disasm" => "disassemble OWNER [--span BYTES]",
             "imports" => "inspect OWNER [--span BYTES]",
             _ => return decompile::cli::entry(&["--help".to_string()]),

--- a/tools/alchemy/src/scaffold.rs
+++ b/tools/alchemy/src/scaffold.rs
@@ -14,7 +14,6 @@
 //! agent's work, scored with diff --unit until every previously
 //! exact owner is exact again.
 
-use compiler_core::build_io::read_json;
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::fs;
@@ -29,7 +28,7 @@ struct Row {
 }
 
 pub fn entry(args: &[String]) -> ExitCode {
-    match run(args) {
+    match scaffold(&compiler_core::routing::root(), args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");
@@ -38,7 +37,9 @@ pub fn entry(args: &[String]) -> ExitCode {
     }
 }
 
-fn run(args: &[String]) -> Result<(), String> {
+/// Every input and output is resolved against `root`, so the operation does
+/// not depend on the process working directory.
+fn scaffold(root: &Path, args: &[String]) -> Result<(), String> {
     const USAGE: &str =
         "usage: alchemy unit scaffold <game> <unit-id> <start-hex> <end-hex> [--apply]";
     if args == ["--help"] || args == ["-h"] {
@@ -54,11 +55,15 @@ fn run(args: &[String]) -> Result<(), String> {
         .map_err(|_| "start is not hex")?;
     let end =
         u32::from_str_radix(end_hex.trim_start_matches("0x"), 16).map_err(|_| "end is not hex")?;
-    let inventory: Value = read_json(Path::new(&format!(
-        "out/{game}-en/full/rebuilt.owner-inventory.json"
-    )))?;
-    let manifest_path = format!("games/{game}/recon/translation-units.json");
-    let mut manifest: Value = read_json(Path::new(&manifest_path))?;
+    let inventory: Value = compiler_core::build_io::read_json(
+        &root.join(format!("out/{game}-en/full/rebuilt.owner-inventory.json")),
+    )?;
+    let manifest_relative = format!("games/{game}/recon/translation-units.json");
+    let manifest_path = root.join(&manifest_relative);
+    let manifest_text = fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("{}: {e}", manifest_path.display()))?;
+    let manifest: Value = serde_json::from_str(&manifest_text)
+        .map_err(|e| format!("{}: {e}", manifest_path.display()))?;
     // Owners already claimed by a declared unit are excluded: overlapping
     // declarations can never coexist, and the fix is extending that unit.
     let mut declared: BTreeSet<u32> = BTreeSet::new();
@@ -99,7 +104,10 @@ fn run(args: &[String]) -> Result<(), String> {
                 "../../../{}",
                 source.replace(&format!("games/{game}/"), "")
             ))
-        } else if Path::new(&format!("games/{game}/recon/en/main/{hex}.c")).exists() {
+        } else if root
+            .join(format!("games/{game}/recon/en/main/{hex}.c"))
+            .exists()
+        {
             Some(format!("../main/{hex}.c"))
         } else {
             None
@@ -119,6 +127,19 @@ fn run(args: &[String]) -> Result<(), String> {
     if rows.is_empty() {
         return Err("no owners in range".into());
     }
+    // Every refusal comes before the first write, so neither the composite nor
+    // the printed entry can preview a unit that cannot be declared.
+    if let Some(refusal) = hole_refusal(unit_id, &rows) {
+        return Err(refusal);
+    }
+    if manifest["units"]
+        .as_array()
+        .ok_or("manifest lacks units")?
+        .iter()
+        .any(|declared| declared["id"] == *unit_id.as_str())
+    {
+        return Err(format!("unit {unit_id} already declared"));
+    }
     let mut lines = vec![
         format!("/* Translation unit {unit_id}: 0x{start_hex} .. 0x{end_hex}."),
         " * Address-ordered composite; holes stay retained assembly and are listed".into(),
@@ -135,8 +156,8 @@ fn run(args: &[String]) -> Result<(), String> {
             )),
         }
     }
+    // The manifest records the composite by its repository-relative path.
     let out = format!("games/{game}/recon/en/units/{unit_id}.c");
-    fs::write(&out, format!("{}\n", lines.join("\n"))).map_err(|e| format!("{out}: {e}"))?;
     let entry = json!({
         "id": unit_id,
         "game": game,
@@ -145,16 +166,24 @@ fn run(args: &[String]) -> Result<(), String> {
         "overlay": null,
         "absolute_symbols": {},
         "local_symbols": [],
-        // True holes (no C anywhere) stay out of the manifest: a listed
-        // retained member must have its draft included from ../main/.
-        "owners": rows.iter().filter(|r| r.include.is_some()).map(|r| json!({
+        // Every row is declared: a range holding a hole was already refused,
+        // because the manifest has no state for one.
+        "owners": rows.iter().map(|r| json!({
             "address": format!("0x{:08x}", r.address),
             "extent": r.extent,
             "state": r.state,
         })).collect::<Vec<_>>(),
     });
-    println!(
-        "wrote {out}: {} owners ({} exact, {} candidates, {} holes{})",
+    // The declaration is prepared, checked and only then written, so a
+    // manifest this scaffold cannot append to leaves no composite behind.
+    // Everything is prepared and checked before the first write, so a range
+    // this scaffold cannot declare leaves nothing on disk at all.
+    let declaration = match apply {
+        false => None,
+        true => Some(append_unit(&manifest_text, &entry)?),
+    };
+    let summary = format!(
+        "{} owners ({} exact, {} candidates, {} holes{})",
         rows.len(),
         rows.iter().filter(|r| r.state == "exact-c").count(),
         rows.iter()
@@ -167,25 +196,415 @@ fn run(args: &[String]) -> Result<(), String> {
             format!("; skipped named-assembly: {}", skipped.join(" "))
         }
     );
-    if apply {
-        let units = manifest["units"]
-            .as_array_mut()
-            .ok_or("manifest lacks units")?;
-        if units.iter().any(|u| u["id"] == *unit_id.as_str()) {
-            return Err(format!("unit {unit_id} already declared"));
-        }
-        units.push(entry);
-        let text = serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
-        fs::write(&manifest_path, format!("{text}\n"))
-            .map_err(|e| format!("{manifest_path}: {e}"))?;
-        println!("declared {unit_id} in {manifest_path}");
-    } else {
+    let Some(updated) = declaration else {
+        // Without --apply the composition is reported, never written: a
+        // composite no manifest entry refers to is litter.
+        println!("{unit_id}: {summary}");
         println!(
             "{}",
             serde_json::to_string_pretty(&entry).map_err(|e| e.to_string())?
         );
+        return Ok(());
+    };
+    let composite = root.join(&out);
+    if let Some(parent) = composite.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
     }
+    fs::write(&composite, format!("{}\n", lines.join("\n")))
+        .map_err(|e| format!("{}: {e}", composite.display()))?;
+    if let Err(error) = fs::write(&manifest_path, updated) {
+        // The composite exists only for the entry that names it.
+        let _ = fs::remove_file(&composite);
+        return Err(format!("{}: {error}", manifest_path.display()));
+    }
+    println!("wrote {out}: {summary}");
+    println!("declared {unit_id} in {manifest_relative}");
     Ok(())
+}
+
+/// An owner with no C anywhere cannot be declared: the manifest's only
+/// retained state requires the member's draft to be included from `../main/`,
+/// and dropping the hole instead leaves a unit that is wholly exact and
+/// ungrouped, which the strict translation-unit check refuses in turn.
+fn hole_refusal(unit_id: &str, rows: &[Row]) -> Option<String> {
+    let holes: Vec<String> = rows
+        .iter()
+        .filter(|row| row.include.is_none())
+        .map(|row| format!("{:08x}", row.address))
+        .collect();
+    (!holes.is_empty()).then(|| {
+        format!(
+            "{unit_id} has no C for {}: a declared retained member's body must be included from ../main/<address>.c, so draft the hole with alchemy decompile before declaring the unit",
+            holes.join(" ")
+        )
+    })
+}
+
+/// The byte offset just past the last entry of the `units` array, with the
+/// indentation that entry is written at. Found by walking the array's own
+/// brackets, so no indentation or line shape is assumed of the file.
+fn last_unit(text: &str) -> Result<(usize, String), String> {
+    const MISSING: &str = "translation-units.json: no units array to append to";
+    let key = text.find("\"units\"").ok_or(MISSING)?;
+    let open = key + text[key..].find('[').ok_or(MISSING)?;
+    let (mut depth, mut in_string, mut escaped) = (0i32, false, false);
+    let (mut first, mut last) = (None, None);
+    for (index, byte) in text.bytes().enumerate().skip(open) {
+        if in_string {
+            match (escaped, byte) {
+                (true, _) => escaped = false,
+                (_, b'\\') => escaped = true,
+                (_, b'"') => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'[' | b'{' => {
+                depth += 1;
+                if depth == 2 && byte == b'{' {
+                    first = Some(index);
+                }
+            }
+            b']' | b'}' => {
+                depth -= 1;
+                if depth == 1 && byte == b'}' {
+                    last = Some(index + 1);
+                }
+                if depth == 0 {
+                    let (first, last) = first
+                        .zip(last)
+                        .ok_or("translation-units.json: the units array is empty")?;
+                    let indent = text[..first].rsplit('\n').next().unwrap_or_default();
+                    return Ok((last, indent.to_string()));
+                }
+            }
+            _ => {}
+        }
+    }
+    Err("translation-units.json: unterminated units array".into())
+}
+
+/// Append one unit in place. The manifest still mixes compact and expanded
+/// entries from its history, so a whole-document rewrite would re-canonicalise
+/// every entry that is still compact and bury the new one in the diff.
+fn append_unit(text: &str, entry: &Value) -> Result<String, String> {
+    let (last, indent) = last_unit(text)?;
+    let rendered = serde_json::to_string_pretty(entry).map_err(|e| e.to_string())?;
+    let updated = format!(
+        "{},\n{indent}{}{}",
+        &text[..last],
+        rendered.replace('\n', &format!("\n{indent}")),
+        &text[last..]
+    );
+    // A wrong insertion point can still leave parseable JSON, so the result is
+    // read back and compared with the document it has to be: the original with
+    // this one entry appended and nothing else moved.
+    let mut expected: Value =
+        serde_json::from_str(text).map_err(|e| format!("translation-units.json: {e}"))?;
+    expected["units"]
+        .as_array_mut()
+        .ok_or("translation-units.json: units must be an array")?
+        .push(entry.clone());
+    let parsed: Value =
+        serde_json::from_str(&updated).map_err(|e| format!("translation-units.json: {e}"))?;
+    if parsed != expected {
+        return Err("translation-units.json: the splice changed the entries around it".into());
+    }
+    Ok(updated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = concat!(
+        "{\n",
+        "  \"format\": \"translation-units\",\n",
+        "  \"units\": [\n",
+        "    {\"id\":\"compact\",\"game\":\"gs1\",\"owners\":[]},\n",
+        "    {\n      \"id\": \"expanded\",\n      \"game\": \"gs1\",\n      \"owners\": []\n    }\n",
+        "  ]\n",
+        "}\n"
+    );
+
+    /// A scaffolding tree: one exact owner in production, plus a second owner
+    /// that is either drafted or a true hole.
+    fn tree(drafted: bool) -> tempfile::TempDir {
+        let tree = tempfile::tempdir().unwrap();
+        let root = tree.path();
+        let write = |relative: &str, text: &str| {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().expect("fixture parent")).unwrap();
+            std::fs::write(path, text).unwrap();
+        };
+        let owner = |address: &str, exact: bool| {
+            json!({
+                "container": {"kind": "main-rom"},
+                "address": address,
+                "registration": {"source_path": if exact { json!("runtime/exact.c") } else { Value::Null }},
+                "production": {
+                    "state": if exact { "exact-c" } else { "retained-assembly" },
+                    "source": if exact { json!("games/gs1/src/runtime/exact.c") } else { Value::Null },
+                    "extent_bytes": 64,
+                },
+            })
+        };
+        // The third owner sits past the scaffolded range, so a second unit can
+        // be asked for without reusing an owner the first one claimed.
+        write(
+            "out/gs1-en/full/rebuilt.owner-inventory.json",
+            &json!({"owners": [
+                owner("0x08094400", true),
+                owner("0x08094500", false),
+                owner("0x08094600", true),
+            ]})
+            .to_string(),
+        );
+        write("games/gs1/recon/translation-units.json", MANIFEST);
+        write("games/gs1/src/runtime/exact.c", "void Exact(void) {}\n");
+        if drafted {
+            write(
+                "games/gs1/recon/en/main/08094500.c",
+                "void Draft(void) {}\n",
+            );
+        }
+        tree
+    }
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        args.iter().copied().map(str::to_owned).collect()
+    }
+
+    /// A range holding an owner with no C is refused in both modes, and the
+    /// refusal comes before the composite or the manifest entry is written.
+    #[test]
+    fn a_hole_stops_the_scaffold_before_it_writes() {
+        let tree = tree(false);
+        let root = tree.path();
+        let manifest = root.join("games/gs1/recon/translation-units.json");
+        for extra in [vec![], vec!["--apply"]] {
+            let mut args = argv(&["gs1", "unit-probe", "0x08094400", "0x08094600"]);
+            args.extend(extra.into_iter().map(str::to_owned));
+            let refusal = scaffold(root, &args).unwrap_err();
+            assert!(refusal.contains("has no C for 08094500"), "{refusal}");
+            assert_eq!(std::fs::read_to_string(&manifest).unwrap(), MANIFEST);
+            assert!(!root.join("games/gs1/recon/en/units/unit-probe.c").exists());
+        }
+    }
+
+    /// Declaring a unit adds its entry and leaves every other manifest byte
+    /// alone, including the entry still held in the compact form.
+    #[test]
+    fn declaring_a_unit_rewrites_nothing_around_it() {
+        let tree = tree(true);
+        let root = tree.path();
+        let manifest = root.join("games/gs1/recon/translation-units.json");
+        let args = argv(&["gs1", "unit-probe", "0x08094400", "0x08094600", "--apply"]);
+        scaffold(root, &args).unwrap();
+        let updated = std::fs::read_to_string(&manifest).unwrap();
+        let close = MANIFEST.rfind("\n  ]").unwrap();
+        assert_eq!(updated[..close], MANIFEST[..close]);
+        assert!(updated.ends_with(&MANIFEST[close..]));
+        assert!(updated.contains("{\"id\":\"compact\",\"game\":\"gs1\",\"owners\":[]},"));
+        // The composite is the unit's actual content, so it is read too.
+        let composite = root.join("games/gs1/recon/en/units/unit-probe.c");
+        let text = std::fs::read_to_string(&composite).unwrap();
+        let includes: Vec<&str> = text
+            .lines()
+            .filter(|line| line.starts_with("#include"))
+            .collect();
+        assert_eq!(
+            includes,
+            [
+                "#include \"../../../src/runtime/exact.c\"",
+                "#include \"../main/08094500.c\""
+            ]
+        );
+        let units = serde_json::from_str::<Value>(&updated).unwrap()["units"].clone();
+        let ids: Vec<&str> = units
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|unit| unit["id"].as_str())
+            .collect();
+        assert_eq!(ids, ["compact", "expanded", "unit-probe"]);
+        // The declared unit keeps both owners, the exact one and the drafted,
+        // in address order and with the states the composite reflects.
+        assert_eq!(
+            units[2]["owners"],
+            json!([
+                {"address": "0x08094400", "extent": 64, "state": "exact-c"},
+                {"address": "0x08094500", "extent": 64, "state": "retained-assembly"},
+            ])
+        );
+        assert_eq!(units[2]["source"], "games/gs1/recon/en/units/unit-probe.c");
+        // A whole-document rewrite would have expanded the compact entry.
+        assert_ne!(
+            updated,
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&serde_json::from_str::<Value>(&updated).unwrap())
+                    .unwrap()
+            )
+        );
+
+        // Reusing the id for another range is refused in both modes, before
+        // the composite or the manifest entry is written.
+        let composite = root.join("games/gs1/recon/en/units/unit-probe.c");
+        std::fs::remove_file(&composite).unwrap();
+        for extra in [vec![], vec!["--apply"]] {
+            let mut again = argv(&["gs1", "unit-probe", "0x08094600", "0x08094700"]);
+            again.extend(extra.into_iter().map(str::to_owned));
+            assert_eq!(
+                scaffold(root, &again).unwrap_err(),
+                "unit unit-probe already declared"
+            );
+            assert_eq!(std::fs::read_to_string(&manifest).unwrap(), updated);
+            assert!(!composite.exists());
+        }
+    }
+
+    /// A manifest the scaffold cannot append to leaves no composite behind:
+    /// the declaration is prepared and checked before the first write.
+    #[test]
+    fn a_manifest_that_cannot_be_appended_to_leaves_no_composite() {
+        let tree = tree(true);
+        let root = tree.path();
+        let manifest = root.join("games/gs1/recon/translation-units.json");
+        let empty = "{\n  \"units\": [\n  ]\n}\n";
+        std::fs::write(&manifest, empty).unwrap();
+        let args = argv(&["gs1", "unit-probe", "0x08094400", "0x08094600", "--apply"]);
+        assert_eq!(
+            scaffold(root, &args).unwrap_err(),
+            "translation-units.json: the units array is empty"
+        );
+        assert!(!root.join("games/gs1/recon/en/units/unit-probe.c").exists());
+        assert_eq!(std::fs::read_to_string(&manifest).unwrap(), empty);
+    }
+
+    /// Without --apply nothing reaches disk: a composite no manifest entry
+    /// refers to is litter, and the dry run used to leave one behind.
+    #[test]
+    fn a_dry_run_writes_nothing() {
+        let tree = tree(true);
+        let root = tree.path();
+        let manifest = root.join("games/gs1/recon/translation-units.json");
+        let args = argv(&["gs1", "unit-probe", "0x08094400", "0x08094600"]);
+        scaffold(root, &args).unwrap();
+        assert_eq!(std::fs::read_to_string(&manifest).unwrap(), MANIFEST);
+        assert!(!root.join("games/gs1/recon/en/units").exists());
+    }
+
+    /// The insertion point is the last entry's own closing brace, found by
+    /// walking the array's brackets: a nested object inside that entry, or an
+    /// inline array, must not be mistaken for the end of the units array.
+    #[test]
+    fn the_splice_follows_the_last_entry_not_the_indentation() {
+        let nested = concat!(
+            "{\n",
+            "  \"units\": [\n",
+            "    {\"id\":\"compact\",\"owners\":[]},\n",
+            "    {\n",
+            "      \"id\": \"expanded\",\n",
+            "      \"absolute_symbols\": {\n",
+            "        \"Func_1\": {\"address\": \"0x1\", \"kind\": \"thumb\"}\n",
+            "      },\n",
+            "      \"owners\": [{\"address\": \"0x2\", \"note\": \"] not an end\"}]\n",
+            "    }\n",
+            "  ]\n",
+            "}\n"
+        );
+        let entry = json!({"id": "added", "owners": []});
+        let updated = append_unit(nested, &entry).unwrap();
+        let (last, indent) = last_unit(nested).unwrap();
+        assert_eq!(indent, "    ");
+        assert_eq!(&nested[last - 1..last], "}");
+        assert_eq!(updated[..last], nested[..last]);
+        assert!(updated.ends_with(&nested[last..]));
+        let units = serde_json::from_str::<Value>(&updated).unwrap()["units"].clone();
+        let ids: Vec<&str> = units
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|unit| unit["id"].as_str())
+            .collect();
+        assert_eq!(ids, ["compact", "expanded", "added"]);
+        assert_eq!(units[1]["absolute_symbols"]["Func_1"]["kind"], "thumb");
+        assert_eq!(units[1]["owners"][0]["note"], "] not an end");
+    }
+
+    /// The splice separates the new entry from the one before it, so an empty
+    /// array says so rather than emitting a leading comma.
+    #[test]
+    fn an_empty_units_array_is_refused_rather_than_spliced() {
+        let empty = "{\n  \"units\": [\n  ]\n}\n";
+        assert_eq!(
+            append_unit(empty, &json!({"id": "first"})).unwrap_err(),
+            "translation-units.json: the units array is empty"
+        );
+    }
+
+    /// A range with an owner that has no C anywhere cannot be declared:
+    /// dropping the hole instead leaves a wholly exact ungrouped unit, and
+    /// `diff --unit --first` then fails on an unrelated message.
+    #[test]
+    fn a_range_with_no_c_for_an_owner_is_refused_before_it_is_declared() {
+        let row = |address, include: Option<&str>, state| Row {
+            address,
+            include: include.map(str::to_string),
+            state,
+            extent: 32,
+        };
+        let drafted = [
+            row(
+                0x0809445c,
+                Some("../../../src/runtime/disarm_hblank_dma.c"),
+                "exact-c",
+            ),
+            row(0x080944ec, Some("../main/080944ec.c"), "retained-assembly"),
+        ];
+        assert!(hole_refusal("unit-0809445c", &drafted).is_none());
+        let refusal = hole_refusal(
+            "unit-0809445c",
+            &[
+                row(
+                    0x0809445c,
+                    Some("../../../src/runtime/disarm_hblank_dma.c"),
+                    "exact-c",
+                ),
+                row(0x080944ec, None, "retained-assembly"),
+            ],
+        )
+        .expect("a hole refuses");
+        assert!(refusal.contains("has no C for 080944ec"), "{refusal}");
+        assert!(refusal.contains("../main/<address>.c"), "{refusal}");
+    }
+
+    /// The maintained manifest still mixes compact and expanded entries, so a
+    /// whole-document rewrite reformats entries this scaffold never touched.
+    /// Appending in place has to leave every other byte alone.
+    #[test]
+    fn appending_a_unit_leaves_the_entries_around_it_untouched() {
+        let path = compiler_core::routing::root().join("games/gs1/recon/translation-units.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let entry = json!({"id": "unit-append-check", "game": "gs1", "owners": []});
+        let updated = append_unit(&text, &entry).unwrap();
+        let close = text.rfind("\n  ]").unwrap();
+        assert_eq!(updated[..close], text[..close]);
+        assert!(updated.ends_with(&text[close..]));
+        let mut expected: Value = serde_json::from_str(&text).unwrap();
+        expected["units"].as_array_mut().unwrap().push(entry);
+        assert_eq!(
+            serde_json::from_str::<Value>(&updated).unwrap(),
+            expected,
+            "the append changed the manifest beyond the new unit"
+        );
+        // A whole-document rewrite would not: the file is not canonical.
+        let canonical = format!("{}\n", serde_json::to_string_pretty(&expected).unwrap());
+        assert_ne!(canonical, updated);
+    }
 }
 
 fn hex_of(value: &Value) -> Option<u32> {

--- a/tools/decompile/src/adopt.rs
+++ b/tools/decompile/src/adopt.rs
@@ -3,6 +3,8 @@
 //! records inside the span retire, and the overlay placeholder is applied
 //! through `overlay adopt`. Every step refuses before it mutates when the
 //! candidate is not exact or the span overlaps another registered region.
+//! A main-image owner lands the same records without a placeholder, and
+//! writes nothing until `--apply`.
 
 use crate::owners::{self, modules, parse_owner, score, tool_command};
 use compiler_core::source_paths::{SourceOwner, SourcePaths};
@@ -16,6 +18,8 @@ pub struct Request<'a> {
     pub name: Option<&'a str>,
     pub path: Option<&'a str>,
     pub source: Option<&'a Path>,
+    /// Main-image landings verify by default and only write when asked.
+    pub apply: bool,
 }
 
 /// `FieldScene_RunFlagGatedActorDialogue` becomes `flag_gated_actor_dialogue`.
@@ -113,8 +117,324 @@ fn run_tool(root: &Path, tool: &str, args: &[&str]) -> Result<String, String> {
     ))
 }
 
+/// The retained evidence a main-image owner takes with it: its assembly and
+/// its reconstruction draft both retire when the source lands in production.
+fn main_retirements(root: &Path, stem: &str) -> Vec<PathBuf> {
+    [
+        format!("games/gs1/asm/{stem}.s"),
+        format!("games/gs1/recon/en/main/{stem}.c"),
+    ]
+    .into_iter()
+    .map(|relative| root.join(relative))
+    .filter(|path| path.exists())
+    .collect()
+}
+
+/// Writes one main-image landing: the source lands in production, the
+/// register learns the owner's name and path, and its dossier, assembly and
+/// draft retire. Only the records actually changed are staged.
+fn write_landing(
+    root: &Path,
+    owner: SourceOwner,
+    name: &str,
+    relative: &str,
+    candidate: &Path,
+    retiring: &[PathBuf],
+    destination: &Path,
+) -> Result<Vec<String>, String> {
+    let mut report = Vec::new();
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+    }
+    std::fs::copy(candidate, destination).map_err(|e| format!("{}: {e}", destination.display()))?;
+    let manifest = root.join("games/gs1/source-paths.json");
+    let (mut register, _) = read_json(&manifest)?;
+    set_source(&mut register["owners"][owner.id()], name, relative);
+    write_json(&manifest, &register, true, true)?;
+    let mut staged = vec![destination.to_path_buf(), manifest];
+    let dossiers = root.join("games/gs1/recon/en/dossiers.json");
+    let (mut records, newline) = read_json(&dossiers)?;
+    if records["records"]
+        .as_object_mut()
+        .and_then(|map| map.shift_remove(&owner.id()))
+        .is_some()
+    {
+        write_json(&dossiers, &records, false, newline)?;
+        report.push("dossiers removed: 1".to_string());
+        staged.push(dossiers);
+    }
+    for path in retiring {
+        git(root, &["rm", "-q", &path.to_string_lossy()])?;
+        report.push(format!("retired {}", path.display()));
+    }
+    let staged: Vec<String> = staged
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    let mut args = vec!["add"];
+    args.extend(staged.iter().map(String::as_str));
+    git(root, &args)?;
+    report.push(format!("adopted {} as {name} at {relative}", owner.id()));
+    Ok(report)
+}
+
+/// The records a landing overwrites, kept so a failure can put them back.
+/// A landing touches five things at once, and `check owners` only speaks
+/// afterwards, so a half-applied landing has to be undoable.
+struct Landing {
+    register: (PathBuf, Vec<u8>),
+    dossiers: (PathBuf, Vec<u8>),
+    /// The production file's own bytes when the landing found one there, so
+    /// an overwrite is put back rather than merely left in place.
+    destination: (PathBuf, Option<Vec<u8>>),
+    /// Directories the landing had to create, deepest first, so an undone
+    /// landing does not leave an empty subsystem behind.
+    created: Vec<PathBuf>,
+    /// The retired records' own bytes. Restoring them from the repository
+    /// would bring back the committed version and lose an uncommitted edit,
+    /// so what was on disk is what goes back.
+    retiring: Vec<(PathBuf, Option<Vec<u8>>)>,
+}
+
+impl Landing {
+    fn read(root: &Path, destination: &Path, retiring: &[PathBuf]) -> Result<Self, String> {
+        let read = |relative: &str| -> Result<(PathBuf, Vec<u8>), String> {
+            let path = root.join(relative);
+            let bytes = std::fs::read(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+            Ok((path, bytes))
+        };
+        Ok(Self {
+            register: read("games/gs1/source-paths.json")?,
+            dossiers: read("games/gs1/recon/en/dossiers.json")?,
+            destination: (destination.to_path_buf(), std::fs::read(destination).ok()),
+            created: destination
+                .ancestors()
+                .skip(1)
+                .take_while(|directory| {
+                    directory.starts_with(root.join("games/gs1/src")) && !directory.exists()
+                })
+                .map(Path::to_path_buf)
+                .collect(),
+            retiring: retiring
+                .iter()
+                .map(|path| (path.clone(), std::fs::read(path).ok()))
+                .collect(),
+        })
+    }
+
+    /// Every step is the undo of one the landing made. What could not be put
+    /// back is named, so a rollback never fails silently.
+    fn undo(&self, root: &Path) -> Vec<String> {
+        let mut unrestored = Vec::new();
+        let mut restore = |path: &Path, bytes: Option<&Vec<u8>>| {
+            let outcome = match bytes {
+                Some(bytes) => {
+                    // Retiring a record empties, and so removes, its directory.
+                    path.parent()
+                        .map_or(Ok(()), std::fs::create_dir_all)
+                        .and_then(|()| std::fs::write(path, bytes))
+                }
+                None => std::fs::remove_file(path),
+            };
+            if let Err(error) = outcome {
+                unrestored.push(format!("{}: {error}", path.display()));
+            }
+        };
+        restore(&self.register.0, Some(&self.register.1));
+        restore(&self.dossiers.0, Some(&self.dossiers.1));
+        restore(&self.destination.0, self.destination.1.as_ref());
+        for (path, bytes) in &self.retiring {
+            if let Some(bytes) = bytes {
+                restore(path, Some(bytes));
+            }
+        }
+        for path in self.retiring.iter().map(|(path, _)| path).chain([
+            &self.destination.0,
+            &self.register.0,
+            &self.dossiers.0,
+        ]) {
+            let _ = git(root, &["reset", "-q", "--", &path.to_string_lossy()]);
+        }
+        for directory in &self.created {
+            let _ = std::fs::remove_dir(directory);
+        }
+        unrestored
+    }
+}
+
+/// Reports a failed landing, naming anything the rollback could not undo.
+fn rolled_back(root: &Path, backup: &Landing, error: &str) -> String {
+    match backup.undo(root).as_slice() {
+        [] => format!("{error}; the landing was rolled back"),
+        left => format!(
+            "{error}; the landing was rolled back except: {}",
+            left.join("; ")
+        ),
+    }
+}
+
+/// Writes one main-image landing and hands back what it overwrote, so the
+/// caller can undo it if the owner check that follows disagrees. A failure
+/// inside the landing undoes itself before it returns.
+fn land_main_records(
+    root: &Path,
+    owner: SourceOwner,
+    name: &str,
+    relative: &str,
+    candidate: &Path,
+    retiring: &[PathBuf],
+) -> Result<(Vec<String>, Landing), String> {
+    let destination = root.join("games/gs1/src").join(relative);
+    let backup = Landing::read(root, &destination, retiring)?;
+    match write_landing(
+        root,
+        owner,
+        name,
+        relative,
+        candidate,
+        retiring,
+        &destination,
+    ) {
+        Ok(report) => Ok((report, backup)),
+        Err(error) => Err(rolled_back(root, &backup, &error)),
+    }
+}
+
+/// A main-image landing, in the record shape the maintained history uses.
+/// The candidate is verified first and nothing is written without `--apply`.
+/// A member of a declared translation unit is refused: a shared owner is
+/// installed with its unit, not through an isolated adoption.
+fn adopt_main(root: &Path, request: &Request) -> Result<Vec<String>, String> {
+    let owner = SourceOwner::parse_argument(request.owner)?;
+    let stem = owner.legacy_stem();
+    if let Some(unit) = compiler_core::translation_units::TranslationUnits::load(root)?
+        .unit_for_game_owner("gs1", owner)
+    {
+        return Err(format!(
+            "{} is declared by translation unit {}; install a shared owner with its unit, not through an isolated adoption",
+            owner.id(),
+            unit.id
+        ));
+    }
+    let span = match request.span {
+        Some(span) => span,
+        None => diff::render::region_size(root, owner.address())
+            .and_then(|size| u32::try_from(size).ok())
+            .ok_or_else(|| {
+                format!("no owner-size entry for {stem} in the claimed or asm build manifests; run make build-claimed or pass --span BYTES")
+            })?,
+    };
+    let record =
+        read_json(&root.join("games/gs1/source-paths.json"))?.0["owners"][owner.id()].clone();
+    // An owner whose register already names a production source is verified,
+    // never landed again, whatever --path was asked for: a second landing
+    // would copy reviewed C to a new path and leave the old file behind.
+    let registered = record["source"].as_str().map(str::to_string);
+    if let Some(existing) = registered.as_deref() {
+        // Refused whenever a landing is even proposed: with --apply, and in a
+        // dry run that plans a second path for C already in production.
+        if request.apply || request.path.is_some_and(|path| path != existing) {
+            return Err(format!(
+                "{} is already adopted as C at games/gs1/src/{existing}; nothing written",
+                request.owner
+            ));
+        }
+    }
+    let name = request
+        .name
+        .map(str::to_string)
+        .or_else(|| record["name"].as_str().map(str::to_string))
+        .ok_or_else(|| format!("{} has no registered name; pass --name NAME", owner.id()))?;
+    // The production directory expresses an evidenced subsystem, which the
+    // owner's address and name cannot establish on their own.
+    let relative = request
+        .path
+        .map(str::to_string)
+        .or_else(|| registered.clone())
+        .ok_or_else(|| {
+            format!(
+                "{} has no registered source path; pass --path SUBSYSTEM/FILE.c",
+                owner.id()
+            )
+        })?;
+    let production = Path::new(&relative);
+    if production.is_absolute()
+        || production
+            .components()
+            .any(|part| part == std::path::Component::ParentDir)
+        || production.extension().and_then(|kind| kind.to_str()) != Some("c")
+    {
+        return Err(format!(
+            "{relative}: a production path is a relative C file under games/gs1/src"
+        ));
+    }
+    let destination = root.join("games/gs1/src").join(production);
+    let landed = registered.is_some() && destination.is_file();
+    let draft = root.join(format!("games/gs1/recon/en/main/{stem}.c"));
+    let candidate = match request.source {
+        Some(source) => source.to_path_buf(),
+        None if draft.is_file() => draft,
+        None if landed => destination.clone(),
+        None => {
+            return Err(format!(
+                "no candidate for {}; pass --source FILE",
+                owner.id()
+            ))
+        }
+    };
+    let result = score(root, &candidate, request.owner, span)?;
+    let mut report = vec![format!(
+        "candidate={} reference={} differing_halfwords={} span={span}",
+        result.candidate, result.reference, result.differing
+    )];
+    if result.differing != 0 {
+        return Err(format!(
+            "{} is not exact ({} differing halfwords); nothing adopted",
+            request.owner, result.differing
+        ));
+    }
+    let retiring = main_retirements(root, &stem);
+    if !request.apply {
+        report.push(match landed {
+            true => format!("already registered as {name} at {relative}; nothing to record"),
+            false => format!("would register {} as {name} at {relative}", owner.id()),
+        });
+        for path in &retiring {
+            report.push(format!("would retire {}", path.display()));
+        }
+        report.push("adopt=verified".to_string());
+        return Ok(report);
+    }
+    let (landed_lines, backup) =
+        land_main_records(root, owner, &name, &relative, &candidate, &retiring)?;
+    report.extend(landed_lines);
+    let verdict = match run_tool(root, "check", &["owners"]) {
+        Ok(checked) => checked.trim().lines().last().unwrap_or("").to_string(),
+        Err(error) => return Err(rolled_back(root, &backup, &error)),
+    };
+    if !verdict.contains("owner registers ok") {
+        return Err(rolled_back(
+            root,
+            &backup,
+            &format!("owner check failed after adoption: {verdict}"),
+        ));
+    }
+    report.push(verdict);
+    report.push("adopt=applied".to_string());
+    Ok(report)
+}
+
 /// Adopts one owner. Returns the lines worth reporting.
 pub fn adopt(root: &Path, request: &Request) -> Result<Vec<String>, String> {
+    if SourceOwner::parse_argument(request.owner)?.is_main() {
+        return adopt_main(root, request);
+    }
+    if request.apply {
+        return Err(
+            "--apply is the main-image landing switch; an overlay adoption applies as it lands"
+                .into(),
+        );
+    }
     let (overlay, entry) = parse_owner(request.owner)?;
     let owner = SourceOwner::parse(&format!("{overlay}:{entry:08x}"))?;
     let span = owners::span_for(root, &overlay, entry, request.span)?;
@@ -356,6 +676,370 @@ mod tests {
         set_source(&mut legacy, "SceneActor_MoveAndRedraw", "scene/move.c");
         assert_eq!(legacy["name"], "SceneActor_MoveAndRedraw");
         assert_eq!(legacy["source"], "scene/move.c");
+    }
+
+    /// The retained evidence that retires with a landing, read from the
+    /// fixture tree so that adopting or renaming a real owner cannot fail it.
+    /// The refusals these two pinned owners used to cover are asserted by
+    /// `a_main_landing_refuses_before_it_compiles` over derived owners.
+    #[test]
+    fn a_main_owner_retires_its_assembly_and_its_draft() {
+        let (tree, assembly, draft) = landing_fixture(true);
+        let root = tree.path();
+        assert_eq!(main_retirements(root, "0808e4b4"), vec![assembly, draft]);
+        assert!(main_retirements(root, "08000000").is_empty());
+    }
+
+    fn request<'a>(
+        owner: &'a str,
+        name: Option<&'a str>,
+        path: Option<&'a str>,
+        apply: bool,
+    ) -> Request<'a> {
+        Request {
+            owner,
+            span: None,
+            name,
+            path,
+            source: None,
+            apply,
+        }
+    }
+
+    /// Owners are chosen from the maintained records rather than pinned, so
+    /// adopting, renaming or regrouping any one of them cannot fail these.
+    fn register(root: &Path) -> Value {
+        read_json(&root.join("games/gs1/source-paths.json"))
+            .unwrap()
+            .0
+    }
+
+    /// A standalone main owner the register already places in production.
+    fn a_landed_main_owner(root: &Path) -> (String, String) {
+        let units = compiler_core::translation_units::TranslationUnits::load(root).unwrap();
+        register(root)["owners"]
+            .as_object()
+            .unwrap()
+            .iter()
+            .find_map(|(id, record)| {
+                let source = record["source"].as_str()?;
+                let owner = SourceOwner::parse_argument(id).ok()?;
+                (owner.is_main()
+                    && units.unit_for_game_owner("gs1", owner).is_none()
+                    && root.join("games/gs1/src").join(source).is_file())
+                .then(|| (id.clone(), source.to_string()))
+            })
+            .expect("a landed standalone main owner")
+    }
+
+    /// A main owner a declared translation unit already composes.
+    fn a_main_unit_member(root: &Path) -> (String, String) {
+        compiler_core::translation_units::TranslationUnits::load(root)
+            .unwrap()
+            .units
+            .iter()
+            .filter(|unit| unit.game == "gs1" && unit.overlay.is_none())
+            .find_map(|unit| {
+                let member = unit.owners.first()?;
+                Some((format!("main:{:08x}", member.address), unit.id.clone()))
+            })
+            .expect("a declared main translation unit")
+    }
+
+    /// A main draft the register does not name at all.
+    fn an_unnamed_main_owner(root: &Path) -> String {
+        let register = register(root);
+        let owners = register["owners"].as_object().unwrap();
+        let units = compiler_core::translation_units::TranslationUnits::load(root).unwrap();
+        let mut drafts: Vec<String> = std::fs::read_dir(root.join("games/gs1/recon/en/main"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                let stem = path.file_stem()?.to_str()?.to_string();
+                let id = format!("main:{stem}");
+                // A unit member is refused earlier, on a different message.
+                let owner = SourceOwner::parse_argument(&id).ok()?;
+                (path.extension()? == "c"
+                    && !owners.contains_key(&id)
+                    && units.unit_for_game_owner("gs1", owner).is_none())
+                .then_some(stem)
+            })
+            .collect();
+        drafts.sort();
+        format!("main:{}", drafts.first().expect("an unnamed main draft"))
+    }
+
+    /// The refusals a main landing makes before it compiles anything.
+    #[test]
+    fn a_main_landing_refuses_before_it_compiles() {
+        let root = owners::root();
+        let (member, unit) = a_main_unit_member(&root);
+        let shared = adopt(&root, &request(&member, None, None, false)).unwrap_err();
+        assert!(
+            shared.contains(&format!("declared by translation unit {unit}")),
+            "{shared}"
+        );
+
+        let unnamed = an_unnamed_main_owner(&root);
+        let no_name = adopt(&root, &request(&unnamed, None, None, false)).unwrap_err();
+        assert!(no_name.contains("has no registered name"), "{no_name}");
+        let no_path = adopt(
+            &root,
+            &request(&unnamed, Some("Runtime_Probe"), None, false),
+        )
+        .unwrap_err();
+        assert!(
+            no_path.contains("has no registered source path"),
+            "{no_path}"
+        );
+        let escaping = adopt(
+            &root,
+            &request(
+                &unnamed,
+                Some("Runtime_Probe"),
+                Some("../../elsewhere.c"),
+                false,
+            ),
+        )
+        .unwrap_err();
+        assert!(
+            escaping.contains("relative C file under games/gs1/src"),
+            "{escaping}"
+        );
+
+        // An owner already in production is refused however --path is spelled,
+        // and a dry run may not advertise a second path for it either: the
+        // register, not the requested destination, decides.
+        let (landed, source) = a_landed_main_owner(&root);
+        let refusal =
+            format!("{landed} is already adopted as C at games/gs1/src/{source}; nothing written");
+        for (path, apply) in [
+            (None, true),
+            (Some("menu/elsewhere.c"), true),
+            (Some("menu/elsewhere.c"), false),
+        ] {
+            assert_eq!(
+                adopt(&root, &request(&landed, None, path, apply)).unwrap_err(),
+                refusal
+            );
+        }
+        assert!(!root.join("games/gs1/src/menu/elsewhere.c").exists());
+
+        let overlay =
+            adopt(&root, &request("resource_378:0200088c", None, None, true)).unwrap_err();
+        assert!(
+            overlay.contains("--apply is the main-image landing switch"),
+            "{overlay}"
+        );
+    }
+
+    /// A landing scores the candidate before it records anything, and a dry
+    /// run records nothing at all. The inexact candidate is a stub for the
+    /// owner, so no maintained draft becoming exact can fail this.
+    #[test]
+    fn a_main_landing_verifies_before_it_writes() {
+        let root = owners::root();
+        let (landed, source) = a_landed_main_owner(&root);
+        let address = SourceOwner::parse_argument(&landed).unwrap().address_stem();
+        let stub = tempfile::Builder::new().suffix(".c").tempfile().unwrap();
+        std::fs::write(
+            stub.path(),
+            format!("#include \"types.h\"\n\nvoid Func_{address}(void)\n{{\n}}\n"),
+        )
+        .unwrap();
+        let manifest = root.join("games/gs1/source-paths.json");
+        let before = std::fs::read(&manifest).unwrap();
+
+        let mut stubbed = request(&landed, None, None, false);
+        stubbed.source = Some(stub.path());
+        let inexact = adopt(&root, &stubbed).unwrap_err();
+        assert!(inexact.contains("is not exact ("), "{inexact}");
+
+        let verified = adopt(&root, &request(&landed, None, None, false)).unwrap();
+        assert!(
+            verified[0].contains("differing_halfwords=0"),
+            "{:?}",
+            verified[0]
+        );
+        assert!(
+            verified
+                .iter()
+                .any(|line| line.contains(&format!("already registered as"))
+                    && line.contains(&source))
+        );
+        assert_eq!(verified.last().map(String::as_str), Some("adopt=verified"));
+        assert_eq!(std::fs::read(&manifest).unwrap(), before);
+    }
+
+    /// A fixture landing tree for `main:0808e4b4`.    /// A fixture landing tree for `main:0808e4b4`; `tracked` commits the
+    /// retained records a landing has to retire.
+    fn landing_fixture(tracked: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tree = tempfile::tempdir().unwrap();
+        let root = tree.path().to_path_buf();
+        let write = |relative: &str, text: &str| {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().expect("fixture parent")).unwrap();
+            std::fs::write(&path, text).unwrap();
+            path
+        };
+        write(
+            "games/gs1/source-paths.json",
+            r#"{"owners":{"main:0808e4b4":{"name":"BattleEffect_FindMatchingEvent"}}}"#,
+        );
+        write(
+            "games/gs1/recon/en/dossiers.json",
+            r#"{"records":{"main:0808e4b4":{"owner_bytes":292},"main:0808e23c":{}}}"#,
+        );
+        let assembly = write("games/gs1/asm/0808e4b4.s", "@ retained\n");
+        let draft = write(
+            "games/gs1/recon/en/main/0808e4b4.c",
+            "void BattleEffect_FindMatchingEvent(void) {}\n",
+        );
+        git(&root, &["init", "-q", "-b", "fixture"]).unwrap();
+        if tracked {
+            git(&root, &["add", "-A"]).unwrap();
+            git(
+                &root,
+                &[
+                    "-c",
+                    "user.name=fixture",
+                    "-c",
+                    "user.email=fixture@example.com",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "fixture",
+                ],
+            )
+            .unwrap();
+        }
+        (tree, assembly, draft)
+    }
+
+    const LANDED_PATH: &str = "battle/effects/find_matching_event.c";
+
+    fn land(root: &Path, draft: &Path, retiring: &[PathBuf]) -> Result<Vec<String>, String> {
+        land_main_records(
+            root,
+            SourceOwner::parse_argument("main:0808e4b4").unwrap(),
+            "BattleEffect_FindMatchingEvent",
+            LANDED_PATH,
+            draft,
+            retiring,
+        )
+        .map(|(report, _)| report)
+    }
+
+    /// A whole main-image landing written into a fixture tree and read back,
+    /// in the record shape `6eb123ae3` and `ab2ac2533` use: production source,
+    /// register entry, dossier removal, and the assembly and draft retired.
+    #[test]
+    fn a_main_landing_writes_the_recorded_shape() {
+        let (tree, assembly, draft) = landing_fixture(true);
+        let root = tree.path();
+        let retiring = main_retirements(root, "0808e4b4");
+        assert_eq!(retiring, vec![assembly.clone(), draft.clone()]);
+        let report = land(root, &draft, &retiring).unwrap_or_else(|error| panic!("{error}"));
+
+        let read = |path: &str| std::fs::read_to_string(root.join(path)).unwrap();
+        assert_eq!(
+            read(&format!("games/gs1/src/{LANDED_PATH}")),
+            "void BattleEffect_FindMatchingEvent(void) {}\n"
+        );
+        let register: Value = serde_json::from_str(&read("games/gs1/source-paths.json")).unwrap();
+        assert_eq!(
+            register["owners"]["main:0808e4b4"],
+            serde_json::json!({
+                "name": "BattleEffect_FindMatchingEvent",
+                "source": LANDED_PATH
+            })
+        );
+        let dossiers: Value =
+            serde_json::from_str(&read("games/gs1/recon/en/dossiers.json")).unwrap();
+        assert!(dossiers["records"]["main:0808e4b4"].is_null());
+        assert!(dossiers["records"]["main:0808e23c"].is_object());
+        assert!(!assembly.exists() && !draft.exists());
+        assert_eq!(
+            report,
+            [
+                "dossiers removed: 1".to_string(),
+                format!("retired {}", assembly.display()),
+                format!("retired {}", draft.display()),
+                format!("adopted main:0808e4b4 as BattleEffect_FindMatchingEvent at {LANDED_PATH}"),
+            ]
+        );
+    }
+
+    /// The rollback the owner check reaches for once a landing has already
+    /// succeeded. By then the retirements are staged deletions, so they have
+    /// to come back from HEAD rather than from the index that recorded them.
+    #[test]
+    fn a_landing_undone_after_it_succeeded_puts_every_record_back() {
+        let (tree, assembly, draft) = landing_fixture(true);
+        let root = tree.path();
+        let read = |path: &str| std::fs::read(root.join(path)).unwrap();
+        let (register, dossiers) = (
+            read("games/gs1/source-paths.json"),
+            read("games/gs1/recon/en/dossiers.json"),
+        );
+        let destination = root.join("games/gs1/src").join(LANDED_PATH);
+        let retiring = main_retirements(root, "0808e4b4");
+        let (_, backup) = land_main_records(
+            root,
+            SourceOwner::parse_argument("main:0808e4b4").unwrap(),
+            "BattleEffect_FindMatchingEvent",
+            LANDED_PATH,
+            &draft,
+            &retiring,
+        )
+        .unwrap_or_else(|error| panic!("{error}"));
+        assert!(destination.is_file() && !assembly.exists() && !draft.exists());
+
+        assert_eq!(backup.undo(root), Vec::<String>::new());
+        assert_eq!(read("games/gs1/source-paths.json"), register);
+        assert_eq!(read("games/gs1/recon/en/dossiers.json"), dossiers);
+        assert!(assembly.exists() && draft.exists());
+        assert!(!destination.exists());
+        // The subsystem directories the landing created go with it.
+        assert!(!root.join("games/gs1/src").exists());
+    }
+
+    /// A landing touches five records before `check owners` can speak, so a
+    /// failure part-way has to leave the tree as it found it. Here the
+    /// retained records are untracked, so retiring them fails after the
+    /// register, the dossier and the production source were already written.
+    #[test]
+    fn a_failed_landing_puts_every_record_back() {
+        let (tree, assembly, draft) = landing_fixture(false);
+        let root = tree.path();
+        let before = |path: &str| std::fs::read(root.join(path)).unwrap();
+        let (register, dossiers) = (
+            before("games/gs1/source-paths.json"),
+            before("games/gs1/recon/en/dossiers.json"),
+        );
+        // A landing overwrites whatever production held, so that file is part
+        // of what has to come back.
+        let destination = root.join("games/gs1/src").join(LANDED_PATH);
+        std::fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        std::fs::write(&destination, "void Reviewed(void) {}\n").unwrap();
+
+        let retiring = main_retirements(root, "0808e4b4");
+        let error = land(root, &draft, &retiring).unwrap_err();
+        assert!(error.contains("the landing was rolled back"), "{error}");
+        assert!(!error.contains("except:"), "{error}");
+        assert_eq!(before("games/gs1/source-paths.json"), register);
+        assert_eq!(before("games/gs1/recon/en/dossiers.json"), dossiers);
+        assert_eq!(
+            std::fs::read_to_string(&destination).unwrap(),
+            "void Reviewed(void) {}\n"
+        );
+        assert!(assembly.exists() && draft.exists());
+
+        // With nothing there before, the rollback removes what it copied.
+        std::fs::remove_file(&destination).unwrap();
+        assert!(land(root, &draft, &retiring).is_err());
+        assert!(!destination.exists());
     }
 
     #[test]

--- a/tools/decompile/src/cli.rs
+++ b/tools/decompile/src/cli.rs
@@ -12,9 +12,12 @@ struct Options {
     out: Option<PathBuf>,
     path: Option<String>,
     source: Option<PathBuf>,
+    apply: bool,
 }
 
-fn parse(arguments: &[String]) -> Result<Options, String> {
+/// `--apply` belongs to the main-image landing, so it is a flag of `adopt`
+/// alone; every other operation keeps rejecting it as unknown.
+fn parse(command: &str, arguments: &[String]) -> Result<Options, String> {
     let mut options = Options {
         positional: Vec::new(),
         span: None,
@@ -22,6 +25,7 @@ fn parse(arguments: &[String]) -> Result<Options, String> {
         out: None,
         path: None,
         source: None,
+        apply: false,
     };
     let mut iter = arguments.iter();
     while let Some(argument) = iter.next() {
@@ -42,6 +46,7 @@ fn parse(arguments: &[String]) -> Result<Options, String> {
             "--out" => options.out = Some(PathBuf::from(value("--out")?)),
             "--path" => options.path = Some(value("--path")?),
             "--source" => options.source = Some(PathBuf::from(value("--source")?)),
+            "--apply" if command == "adopt" => options.apply = true,
             other if other.starts_with("--") => return Err(format!("unknown flag {other}")),
             other => options.positional.push(other.to_string()),
         }
@@ -77,7 +82,7 @@ pub fn entry(arguments: &[String]) -> ExitCode {
         return ExitCode::from(2);
     };
     let root = owners::root();
-    let result = parse(&arguments[1..]).and_then(|options| match command {
+    let result = parse(command, &arguments[1..]).and_then(|options| match command {
         "draft" => draft(&root, &options).map(|_| 0),
         "adopt" => adopt_owner(&root, &options).map(|_| 0),
         "imports" => imports_owner(&root, &options),
@@ -136,6 +141,7 @@ fn adopt_owner(root: &Path, options: &Options) -> Result<(), String> {
         name: options.name.as_deref(),
         path: options.path.as_deref(),
         source: options.source.as_deref(),
+        apply: options.apply,
     };
     for line in crate::adopt::adopt(root, &request)? {
         println!("{line}");
@@ -154,4 +160,19 @@ fn imports_owner(root: &Path, options: &Options) -> Result<i32, String> {
         );
     }
     Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    /// The landing switch reached the shared flag loop, where `draft`,
+    /// `disasm` and `imports` would have accepted and ignored it.
+    #[test]
+    fn the_landing_switch_belongs_to_adopt_alone() {
+        let apply = ["--apply".to_string()];
+        let parsed = |command| super::parse(command, &apply).map(|options| options.apply);
+        assert_eq!(parsed("adopt"), Ok(true));
+        for other in ["draft", "disasm", "imports"] {
+            assert_eq!(parsed(other), Err("unknown flag --apply".to_string()));
+        }
+    }
 }

--- a/tools/decompile/src/owners.rs
+++ b/tools/decompile/src/owners.rs
@@ -268,6 +268,7 @@ mod owner_tests {
                 name: None,
                 path: None,
                 source: None,
+                apply: false,
             }
         )
         .is_err());

--- a/tools/overlay-adopt/src/score.rs
+++ b/tools/overlay-adopt/src/score.rs
@@ -12,7 +12,7 @@ use disassemble::compile::compile_overlay_c;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 fn nonowner_relationship(
     kind: &str,
     entry: SourceOwner,
@@ -78,46 +78,73 @@ fn source_for(root: &Path, paths: &SourcePaths, owner: SourceOwner) -> Result<Pa
         .find(|candidate| candidate.exists())
         .ok_or_else(|| format!("no source for {}", owner.id()))
 }
-pub fn run(root: &Path, argv: &[String]) -> Result<i32, String> {
-    let (mut align, mut asm, mut target, mut owner_target, mut override_span) =
-        (false, false, None, None, None);
-    let mut args = argv.iter();
-    while let Some(argument) = args.next() {
-        match argument.as_str() {
-            "--flags" | "--remove-flags" | "--family" => {
-                return Err(format!(
-                    "{argument} is retired; candidates use their canonical compiler route"
-                ));
+#[derive(Default)]
+struct Arguments {
+    target: Option<String>,
+    owner: Option<String>,
+    span: Option<usize>,
+    align: bool,
+    first: bool,
+    allocator_order: bool,
+    asm: bool,
+}
+impl Arguments {
+    /// `None` means `--help`, already answered.
+    fn parse(argv: &[String]) -> Result<Option<Self>, String> {
+        let mut parsed = Self::default();
+        let mut args = argv.iter();
+        while let Some(argument) = args.next() {
+            match argument.as_str() {
+                "--flags" | "--remove-flags" | "--family" => {
+                    return Err(format!(
+                        "{argument} is retired; candidates use their canonical compiler route"
+                    ));
+                }
+                "--span" => {
+                    parsed.span = Some(
+                        args.next()
+                            .and_then(|value| value.parse().ok())
+                            .filter(|span| *span > 0)
+                            .ok_or("--span wants a positive decimal byte count")?,
+                    )
+                }
+                "--owner" => {
+                    parsed.owner = Some(
+                        args.next()
+                            .ok_or("--owner needs <overlay>:<addressHex>")?
+                            .to_string(),
+                    )
+                }
+                "--align" => parsed.align = true,
+                // Both evidence flags imply the aligned stream. This mirrors
+                // `diff::cli::options_of`, which cannot be shared: it parses a
+                // candidate positional with --rom/--target/--unit, while this
+                // command takes an owner target with --span.
+                "--first" | "--allocator-order" => {
+                    parsed.first |= argument == "--first";
+                    parsed.allocator_order |= argument == "--allocator-order";
+                    parsed.align = true;
+                }
+                "--asm" => parsed.asm = true,
+                "-h" | "--help" => {
+                    println!("usage: overlay score TARGET [--owner OWNER] [--span BYTES] [--align] [--first] [--allocator-order] [--asm]");
+                    return Ok(None);
+                }
+                other if parsed.target.is_none() => parsed.target = Some(other.to_string()),
+                other => return Err(format!("unexpected argument {other:?}")),
             }
-            "--span" => {
-                override_span = Some(
-                    args.next()
-                        .and_then(|value| value.parse().ok())
-                        .filter(|span| *span > 0)
-                        .ok_or("--span wants a positive decimal byte count")?,
-                )
-            }
-            "--owner" => {
-                owner_target = Some(
-                    args.next()
-                        .ok_or("--owner needs <overlay>:<addressHex>")?
-                        .to_string(),
-                )
-            }
-            "--align" => align = true,
-            "--asm" => asm = true,
-            "-h" | "--help" => {
-                println!(
-                    "usage: overlay score TARGET [--owner OWNER] [--span BYTES] [--align] [--asm]"
-                );
-                return Ok(0);
-            }
-            other if target.is_none() => target = Some(other.to_string()),
-            other => return Err(format!("unexpected argument {other:?}")),
         }
+        Ok(Some(parsed))
     }
-    let target = target.ok_or("a <overlay>:<addressHex> or source path is required")?;
-    let resolved = resolve(root, owner_target.as_deref().unwrap_or(&target))?;
+}
+/// Options for the shared renderer. The work directory holds the overlay's
+/// reference image, so it has to outlive the render.
+fn options_for(root: &Path, arguments: &Arguments) -> Result<(Options, TempDir), String> {
+    let target = arguments
+        .target
+        .as_deref()
+        .ok_or("a <overlay>:<addressHex> or source path is required")?;
+    let resolved = resolve(root, arguments.owner.as_deref().unwrap_or(target))?;
     let overlay = resolved.overlay_id().expect("resolved overlay owner");
     let address = i64::from(resolved.address());
     let paths = SourcePaths::load(root)?;
@@ -133,9 +160,9 @@ pub fn run(root: &Path, argv: &[String]) -> Result<i32, String> {
         &crate::reviewed_spans(root)?,
         resolved,
         installed,
-        override_span,
+        arguments.span,
     )?;
-    let explicit = Path::new(&target);
+    let explicit = Path::new(target);
     let source = if explicit.is_file() {
         explicit
             .canonicalize()
@@ -164,8 +191,17 @@ pub fn run(root: &Path, argv: &[String]) -> Result<i32, String> {
     options.owner = Some(address as u32);
     options.overlay = Some(overlay);
     options.size = Some(span);
-    options.align = align;
-    options.asm = asm;
+    options.align = arguments.align;
+    options.first = arguments.first;
+    options.allocator_order = arguments.allocator_order;
+    options.asm = arguments.asm;
+    Ok((options, work))
+}
+pub fn run(root: &Path, argv: &[String]) -> Result<i32, String> {
+    let Some(arguments) = Arguments::parse(argv)? else {
+        return Ok(0);
+    };
+    let (options, _work) = options_for(root, &arguments)?;
     let rendered = render(root, &options)?;
     println!("reference_from=rom representation=loader-runtime container_roundtrip=required");
     print!("{}", rendered.stdout);
@@ -290,6 +326,70 @@ mod tests {
             assert!(run(root, &args).unwrap_err().contains(message));
         }
     }
+    /// The allocator and scheduling evidence CONTRIBUTING names has to reach
+    /// overlay owners: the parser used to reject both flags outright. This
+    /// checks they arrive in the options and that the renderer acts on them.
+    #[test]
+    fn scheduling_evidence_flags_reach_the_shared_renderer() {
+        let root = compiler_core::routing::root();
+        let arguments = |argv: &[&str]| {
+            Arguments::parse(&argv.iter().copied().map(str::to_owned).collect::<Vec<_>>())
+                .unwrap()
+                .unwrap()
+        };
+        let target = "resource_378:0200088c";
+        let (plain, _work) = options_for(root, &arguments(&[target])).unwrap();
+        assert_eq!(
+            (plain.align, plain.first, plain.allocator_order),
+            (false, false, false)
+        );
+        for (flag, expected) in [
+            ("--first", (true, true, false)),
+            ("--allocator-order", (true, false, true)),
+        ] {
+            let (options, _work) = options_for(root, &arguments(&[target, flag])).unwrap();
+            assert_eq!(
+                (options.align, options.first, options.allocator_order),
+                expected
+            );
+            assert_eq!(options.overlay.as_deref(), Some("resource_378"));
+        }
+
+        // The renderer has to act on both flags, not merely receive them. The
+        // candidate is a stub for a 4,080-byte owner, so it stays divergent
+        // however the maintained drafts move: no real owner becoming exact
+        // can turn these assertions into a failure.
+        let stub = tempfile::Builder::new().suffix(".c").tempfile().unwrap();
+        std::fs::write(
+            stub.path(),
+            "#include \"types.h\"\n\nvoid Func_0200088c(void)\n{\n}\n",
+        )
+        .unwrap();
+        let candidate = stub.path().to_string_lossy().into_owned();
+        let rendered = |flag: &str| {
+            let arguments = arguments(&[&candidate, "--owner", target, flag]);
+            let (options, _work) = options_for(root, &arguments).unwrap();
+            render(root, &options).unwrap().stdout
+        };
+        let (aligned, first, allocator) = (
+            rendered("--align"),
+            rendered("--first"),
+            rendered("--allocator-order"),
+        );
+        assert!(aligned.contains("candidate=2 reference=4080"), "{aligned}");
+        assert!(!aligned.contains("\nshowing="), "--align alone truncated");
+        assert!(first.contains("\nshowing="), "--first did not truncate");
+        assert!(first.lines().count() < aligned.lines().count());
+        assert!(
+            !aligned.contains("\ntriage_final="),
+            "--align alone reported a residual"
+        );
+        assert!(
+            allocator.contains("\ntriage_final="),
+            "--allocator-order reported no residual"
+        );
+    }
+
     fn owner(value: &str) -> SourceOwner {
         SourceOwner::parse_argument(value).unwrap()
     }


### PR DESCRIPTION
Three tooling changes for blockers that recurred across a day of bounded recovery lanes (documented in PR #6, comment 5585328837). Each addresses one demonstrated blocker, reuses the existing module, and carries a regression test.

1. **Reach overlay owners with the allocator and scheduling evidence.** `alchemy inspect allocator resource_NNN:0200xxxx [candidate.c]` and `diff --first` / `--allocator-order` now work for overlay owners; route and bindings follow the owner. Main-ROM output is byte-identical (locked by the existing test). Measured on `resource_378:0200088c`: cse/combine/lreg/greg/sched2 dumps and the allocator report where before there was a refusal.
2. **Land a main-image owner through adopt.** `alchemy adopt main:<addr> --source F --name N --path P` verifies `differing_halfwords=0`, writes only with `--apply`, produces the record shape of the existing main-image landings, refuses an owner that already has a source or belongs to a translation unit, and rolls back on a write or `check owners` failure.
3. **Declare a scaffolded unit without reformatting its manifest.** `unit scaffold --apply` appends the entry in place (measured `16 0` lines instead of a whole-file reformat) and refuses a range holding an undraftable hole before writing.

Checks run on the branch tip: `make test`, `make tooling-size` (43,533 / 50,000), `make tooling-index-check`, `cargo fmt --check`, `make verify`.

Open questions I could not settle without you: the manifest has no state for a true hole (CONTRIBUTING asks for holes to be declared explicitly); whether a shared-unit main owner must be scored through `diff --unit` rather than an isolated adopt; and whether overlay adopt should become verify-first like the main form.
